### PR TITLE
Consertada incompatibilidade com Django 2.0

### DIFF
--- a/djangojs/runners.py
+++ b/djangojs/runners.py
@@ -14,7 +14,7 @@ from tempfile import NamedTemporaryFile, mkstemp
 
 from django.contrib.staticfiles import finders
 from django.core.files.storage import FileSystemStorage
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.template.loader import render_to_string
 from django.test import LiveServerTestCase
 from django.utils.encoding import python_2_unicode_compatible

--- a/djangojs/test_urls.py
+++ b/djangojs/test_urls.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from django import forms
 from django.conf.urls import patterns, url, include
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.views.generic import TemplateView
 from django.views.generic.edit import BaseFormView
 

--- a/djangojs/tests/test_context.py
+++ b/djangojs/tests/test_context.py
@@ -8,7 +8,7 @@ from django.contrib.auth.management import create_permissions
 from django.contrib.auth.models import User
 from django.contrib.contenttypes.management import update_contenttypes
 from django.contrib.sessions.middleware import SessionMiddleware
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.db.models import get_app
 from django.middleware.locale import LocaleMiddleware
 from django.test import TestCase

--- a/djangojs/tests/test_tags.py
+++ b/djangojs/tests/test_tags.py
@@ -1,7 +1,7 @@
 from django.utils import unittest
 
 from django.contrib.staticfiles.templatetags.staticfiles import static
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.template import Context, Template
 from django.test import TestCase
 from django.test.utils import override_settings

--- a/djangojs/tests/test_urls.py
+++ b/djangojs/tests/test_urls.py
@@ -1,7 +1,7 @@
 import json
 
 from django.core.cache import cache
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.test import TestCase
 from django.test.utils import override_settings
 from django.utils import six
@@ -175,7 +175,7 @@ class UrlsTestMixin(object):
 
     @override_settings(JS_CACHE_DURATION=0)
     def test_force_script_name(self):
-        from django.core.urlresolvers import set_script_prefix, _prefixes
+        from django.urls import set_script_prefix, _prefixes
 
         try:
             set_script_prefix("/force_script")
@@ -215,7 +215,7 @@ class UrlsJsonViewTest(UrlsTestMixin, TestCase):
 
     @override_settings(JS_CACHE_DURATION=0)
     def test_force_script_name(self):
-        from django.core.urlresolvers import set_script_prefix, _prefixes
+        from django.urls import set_script_prefix, _prefixes
         try:
             url = reverse('django_js_urls')
             set_script_prefix("/force_script")

--- a/djangojs/urls.py
+++ b/djangojs/urls.py
@@ -3,8 +3,8 @@ import sys
 
 from os.path import join, isdir
 
-from django.conf.urls import url
-from django.views import i18n
+from django.conf.urls import re_path
+from django.views.i18n import JavaScriptCatalog
 
 from djangojs.conf import settings
 from djangojs.views import UrlsJsonView, ContextJsonView, JsInitView
@@ -31,8 +31,8 @@ def js_info_dict():
 
 
 urlpatterns = [
-    url(r'^init\.js$', JsInitView.as_view(), name='django_js_init'),
-    url(r'^urls$', UrlsJsonView.as_view(), name='django_js_urls'),
-    url(r'^context$', ContextJsonView.as_view(), name='django_js_context'),
-    url(r'^translation$', i18n.javascript_catalog, js_info_dict(), name='js_catalog'),
+    re_path(r'^init\.js$', JsInitView.as_view(), name='django_js_init'),
+    re_path(r'^urls$', UrlsJsonView.as_view(), name='django_js_urls'),
+    re_path(r'^context$', ContextJsonView.as_view(), name='django_js_context'),
+    re_path(r'^translation$', JavaScriptCatalog.get(), js_info_dict(), name='js_catalog'),
 ]

--- a/djangojs/urls_serializer.py
+++ b/djangojs/urls_serializer.py
@@ -8,7 +8,7 @@ import sys
 import types
 
 from django.core.serializers.json import DjangoJSONEncoder
-from django.core.urlresolvers import RegexURLPattern, RegexURLResolver, get_script_prefix
+from django.urls import URLPattern as RegexURLPattern, URLResolver as RegexURLResolver, get_script_prefix
 from django.utils import six
 
 from djangojs.conf import settings


### PR DESCRIPTION
Deixa de usar url para usar re_path e o loval de import vai para django.urls