### PR TITLE
compatibilidade com Django 2.2

### DIFF
--- a/djangojs/context_serializer.py
+++ b/djangojs/context_serializer.py
@@ -96,9 +96,9 @@ class ContextSerializer(object):
             'is_superuser': False,
             'permissions': tuple(),
         }
-        if 'django.contrib.sessions.middleware.SessionMiddleware' in settings.MIDDLEWARE_CLASSES:
+        if 'django.contrib.sessions.middleware.SessionMiddleware' in settings.MIDDLEWARE:
             user = self.request.user
-            data['user']['is_authenticated'] = user.is_authenticated()
+            data['user']['is_authenticated'] = user.is_authenticated
             if hasattr(user, 'username'):
                 data['user']['username'] = user.username
             elif hasattr(user, 'get_username'):

--- a/djangojs/urls.py
+++ b/djangojs/urls.py
@@ -10,29 +10,9 @@ from djangojs.conf import settings
 from djangojs.views import UrlsJsonView, ContextJsonView, JsInitView
 
 
-def js_info_dict():
-    js_info_dict = {
-        'packages': [],
-    }
-
-    for app in settings.INSTALLED_APPS:
-        if settings.JS_I18N_APPS and app not in settings.JS_I18N_APPS:
-            continue
-        if settings.JS_I18N_APPS_EXCLUDE and app in settings.JS_I18N_APPS_EXCLUDE:
-            continue
-        if app not in sys.modules:
-            __import__(app)
-        module = sys.modules[app]
-        for path in module.__path__:
-            if isdir(join(path, 'locale')):
-                js_info_dict['packages'].append(app)
-                break
-    return js_info_dict
-
-
 urlpatterns = [
     re_path(r'^init\.js$', JsInitView.as_view(), name='django_js_init'),
     re_path(r'^urls$', UrlsJsonView.as_view(), name='django_js_urls'),
     re_path(r'^context$', ContextJsonView.as_view(), name='django_js_context'),
-    re_path(r'^translation$', JavaScriptCatalog.as_view(), js_info_dict(), name='js_catalog'),
+    re_path(r'^translation$', JavaScriptCatalog.as_view(), name='js_catalog'),
 ]

--- a/djangojs/urls_serializer.py
+++ b/djangojs/urls_serializer.py
@@ -76,7 +76,7 @@ def _get_urls_for_pattern(pattern, prefix='', namespace=None):
                 return {}
             if namespace:
                 pattern_name = ':'.join((namespace, pattern_name))
-            full_url = prefix + pattern.regex.pattern
+            full_url = prefix + pattern.pattern.regex.pattern
             for char in ['^', '$']:
                 full_url = full_url.replace(char, '')
             # remove optionnal non capturing groups
@@ -121,7 +121,7 @@ def _get_urls_for_pattern(pattern, prefix='', namespace=None):
                     continue
                 if settings.JS_URLS_NAMESPACES_EXCLUDE and namespaces in settings.JS_URLS_NAMESPACES_EXCLUDE:
                     continue
-                new_prefix = '%s%s' % (prefix, pattern.regex.pattern)
+                new_prefix = '%s%s' % (prefix, pattern.pattern.regex.pattern)
                 urls.update(_get_urls(pattern.urlconf_name, new_prefix, namespaces))
 
     return urls


### PR DESCRIPTION
forma antiga MIDDLEWARE_CLASSES foi renomeada para MIDDLEWARE no Django 2 https://docs.djangoproject.com/en/2.2/topics/http/middleware/

user.is_authenticated é um bool e não pode ser chamado

def js_info_dict() está depreciado no Django 2.2 https://docs.djangoproject.com/en/2.2/topics/i18n/translation/#module-django.views.i18n